### PR TITLE
Add license field to setup.cfg

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -2,4 +2,5 @@
 universal = 1
 
 [metadata]
+license = BSD
 license_file = LICENSE


### PR DESCRIPTION
My company's auto-procurement software is dumb, and refuses to pick up jupyterlab_pygments for the reason that it cannot determine the license for this project.

To fix this, this PR adds a `license` field to `setup.cfg`. @SylvainCorlay Could I please ask you to pull this in and then do a new release on pypi? Thank you, and sorry for the inconvenience