### PR TITLE
Automated Changelog Entry for 0.1.2 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,4 +2,18 @@
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
+## 0.1.2
+
+([Full Changelog](https://github.com/jupyterlab/jupyterlab_pygments/compare/95039be25bf6ea7cc7545214e0f80e9c8f133a0e...7a0d1788b1ae6a9fa14546e794a83e05e934939e))
+
+### Merged PRs
+
+- Fix CI [#13](https://github.com/jupyterlab/jupyterlab_pygments/pull/13) ([@martinRenou](https://github.com/martinRenou))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyterlab/jupyterlab_pygments/graphs/contributors?from=2020-09-29&to=2022-04-08&type=c))
+
+[@github-actions](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab_pygments+involves%3Agithub-actions+updated%3A2020-09-29..2022-04-08&type=Issues) | [@jtpio](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab_pygments+involves%3Ajtpio+updated%3A2020-09-29..2022-04-08&type=Issues) | [@martinRenou](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab_pygments+involves%3AmartinRenou+updated%3A2020-09-29..2022-04-08&type=Issues) | [@welcome](https://github.com/search?q=repo%3Ajupyterlab%2Fjupyterlab_pygments+involves%3Awelcome+updated%3A2020-09-29..2022-04-08&type=Issues)
+
 <!-- <END NEW CHANGELOG ENTRY> -->


### PR DESCRIPTION
Automated Changelog Entry for 0.1.2 on main
```
Python version: 0.1.2
npm version: jupyterlab_pygments: 0.2.0
```

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyterlab/jupyterlab_pygments  |
| Branch  | main  |
| Version Spec | minor |
| Since | 95039be25bf6ea7cc7545214e0f80e9c8f133a0e |